### PR TITLE
FIxed range setting, settings will be hidden by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,6 +263,7 @@ applySettingsButton.addEventListener('click', () => {
 window.addEventListener('load', () => {
   // Play a random background track when the page loads
   // backgroundMusicPlayer.playRandomTrack();
+  settingsContainer.classList.add('hidden');
 
   toggleBgMusic.addEventListener('click', () => {
     backgroundMusicPlayer.playRandomTrack();


### PR DESCRIPTION
This little Pull Request fixes issue #16 by generating random numbers with `regenerateVar` (which uses the range setting) instead of `generateRandomNumber`. By default, the randomly generated number will still be in between 1 and 10 (because that's the default range setting). Settings will now also be hidden by default so the app will seem more user-friendly (but will be optionally customizable). I hope this helps! 