### PR TITLE
Point the audio players to the proper directory

### DIFF
--- a/resources/js/AudioPlayer.js
+++ b/resources/js/AudioPlayer.js
@@ -66,18 +66,18 @@ class BackgroundMusicPlayer {
 
 // Create an instance of the AudioPlayer class   // Export the instance for use in the mein module
 export const audioPlayer = new AudioPlayer(
-    'audio/success-sound.mp3',
-    'audio/wrong.mp3',
-    'audio/click.mp3',
-    'audio/tick_time_sound.mp3',
-    'audio/tick_time_sound.mp3'
+    'resources/audio/success-sound.mp3',
+    'resources/audio/wrong.mp3',
+    'resources/audio/click.mp3',
+    'resources/audio/tick_time_sound.mp3',
+    'resources/audio/tick_time_sound.mp3'
   );
 
 // Usage
 export const backgroundMusicPlayer = new BackgroundMusicPlayer([
 
-  'audio/lady-of-the-80.mp3',
-  'audio/digital-love.mp3',
-  'audio/a-hero-of-the-80.mp3',
-  'audio/stranger-things.mp3',
+  'resources/audio/lady-of-the-80.mp3',
+  'resources/audio/digital-love.mp3',
+  'resources/audio/a-hero-of-the-80.mp3',
+  'resources/audio/stranger-things.mp3',
 ]);

--- a/resources/js/AudioPlayer.js
+++ b/resources/js/AudioPlayer.js
@@ -66,18 +66,18 @@ class BackgroundMusicPlayer {
 
 // Create an instance of the AudioPlayer class   // Export the instance for use in the mein module
 export const audioPlayer = new AudioPlayer(
-    'audioTracks/success-sound.mp3',
-    'audioTracks/wrong.mp3',
-    'audioTracks/click.mp3',
-    'audioTracks/tick_time_sound.mp3',
-    'audioTracks/tick_time_sound.mp3'
+    'audio/success-sound.mp3',
+    'audio/wrong.mp3',
+    'audio/click.mp3',
+    'audio/tick_time_sound.mp3',
+    'audio/tick_time_sound.mp3'
   );
 
 // Usage
 export const backgroundMusicPlayer = new BackgroundMusicPlayer([
 
-  'audioTracks/lady-of-the-80.mp3',
-  'audioTracks/digital-love.mp3',
-  'audioTracks/a-hero-of-the-80.mp3',
-  'audioTracks/stranger-things.mp3',
+  'audio/lady-of-the-80.mp3',
+  'audio/digital-love.mp3',
+  'audio/a-hero-of-the-80.mp3',
+  'audio/stranger-things.mp3',
 ]);


### PR DESCRIPTION
Due to the audio players seeking for `audioTracks` (which is nonexistent) none of the audio tracks / SFX will be loaded. This Pull Request redirects all audio players to `resources/audio` (an actual folder) instead.